### PR TITLE
fix: use cross-env to set environment variables on all OS platforms

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
       "devDependencies": {
         "@types/node": "17.0.18",
         "@types/react": "17.0.39",
+        "cross-env": "^7.0.3",
         "eslint": "8.9.0",
         "eslint-config-next": "12.1.0",
         "typedoc": "^0.22.12",
@@ -722,6 +723,24 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {
@@ -3456,6 +3475,15 @@
       "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.21.1.tgz",
       "integrity": "sha512-12VZfFIu+wyVbBebyHmRTuEE/tZrB4tJToWcwAMcsp3h4+sHR+fMJWbKpYiCRWlhFBq+KNyO8rIV9rTkeVmznQ==",
       "dev": true
+    },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      }
     },
     "cross-spawn": {
       "version": "7.0.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "NODE_OPTIONS='--inspect=0.0.0.0:9119' next dev",
+    "dev": "cross-env NODE_OPTIONS='--inspect=0.0.0.0:9119' next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"
@@ -16,9 +16,10 @@
   "devDependencies": {
     "@types/node": "17.0.18",
     "@types/react": "17.0.39",
+    "cross-env": "^7.0.3",
     "eslint": "8.9.0",
     "eslint-config-next": "12.1.0",
-    "typescript": "4.5.5",
-    "typedoc": "^0.22.12"
+    "typedoc": "^0.22.12",
+    "typescript": "4.5.5"
   }
 }


### PR DESCRIPTION
Use cross-env: https://www.npmjs.com/package/cross-env

Because setting environment variables on MacOS and Linux differs from Windows
