### PR TITLE
Automatic docker on debug

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,8 @@
         "address": "localhost",
         "localRoot": "${workspaceFolder}/backend",
         "remoteRoot": "/app",
-        "protocol": "inspector"
+        "protocol": "inspector",
+        "preLaunchTask": "start_docker_application"
       },
       {
         "name": "Docker: frontend-server",
@@ -21,7 +22,8 @@
         "address": "localhost",
         "localRoot": "${workspaceFolder}/frontend",
         "remoteRoot": "/app",
-        "protocol": "inspector"
+        "protocol": "inspector",
+        "preLaunchTask": "start_docker_application"
       },
       {
         "name": "Docker: frontend-client",
@@ -33,7 +35,8 @@
         "address": "localhost",
         "localRoot": "${workspaceFolder}/frontend",
         "remoteRoot": "/app",
-        "protocol": "inspector"
+        "protocol": "inspector",
+        "preLaunchTask": "start_docker_application"
       }
     ]
   }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,8 @@
+{
+    "version": "2.0.0",
+    "tasks": [{
+        "label": "start_docker_application",
+        "command": "docker-compose -f docker-compose.debug.yml up -d --build",
+        "type": "shell"
+    }]
+}


### PR DESCRIPTION
This should help a bit with development inside vscode.
When starting the debugger, the debugger will first automatically start the container with the latest changes (that are saved).
This way we don't have to type `docker-compose up...` every time.