### PR TITLE
Prisma env test

### DIFF
--- a/.github/workflows/automatedBackEnd.yml
+++ b/.github/workflows/automatedBackEnd.yml
@@ -18,6 +18,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: Create Prisma Env File
+      run: |
+        touch backend/prisma/.env
+        echo DATABASE_URL="postgresql://osoc2:password@db:5432/osoc2?connect_timeout=30&pool_timeout=30" >> backend/prisma/.env
+        cat backend/prisma/.env
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3
       with:


### PR DESCRIPTION
the backend test now auto generates the .env file this will fix. This fix is also already implemented on the signup branch, but by putting it here for a merge, the other branches can pull this and then their tests will also work again

closes #108