### PR TITLE
fix: actions were running double on development, on push and on pr to main

### DIFF
--- a/.github/workflows/backendCI.yml
+++ b/.github/workflows/backendCI.yml
@@ -6,6 +6,10 @@ on:
   # Run on every open pull request
   pull_request:
     types: [opened, edited, reopened, synchronize]
+
+  # Should run all tests and upload the codecoverage on main
+  push:
+    branches: [main]
   
 jobs:
   ci:

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -8,9 +8,9 @@ on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
 
-  # Should run all tests and upload the codecoverage on main and development
+  # Should run on every push to main
   push:
-    branches: [main, development]
+    branches: [main]
 
 jobs:
   ci:

--- a/.github/workflows/frontendCI.yml
+++ b/.github/workflows/frontendCI.yml
@@ -8,9 +8,9 @@ on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
 
-  # Should run all tests and upload the codecoverage on main and development
+  # Should run all tests and upload the codecoverage on main
   push:
-    branches: [main, development]
+    branches: [main]
 
 jobs:
   ci:


### PR DESCRIPTION
The actions were setup to run on every pr and on every push to main and development. But of course when a PR is created from development it will run on every push to the branch and will every action again because it is a PR.
