### PR TITLE
fix: added a getSessionKey function to be used in useEffect where the sessionKey is needed

### DIFF
--- a/frontend/components/Header/Header.tsx
+++ b/frontend/components/Header/Header.tsx
@@ -46,7 +46,7 @@ export const Header: React.FC = () => {
             <div className={`${styles.links} ${router.pathname !== "/login" ? "" : styles.displayNone}`}>
                 {sessionKey !== "" && !router.pathname.startsWith("/reset") ? <Link href={"/students"}>Students</Link> : null}
                 {sessionKey !== "" && !router.pathname.startsWith("/reset") ? <Link href={"/projects"}>Projects</Link> : null}
-                {isAdmin && router.pathname !== "/reset" ? <Link href={"/users"}>Manage Users</Link> : null}
+                {sessionKey !== "" && isAdmin && !router.pathname.startsWith("/reset") ? <Link href={"/users"}>Manage Users</Link> : null}
                 {router.pathname !== "/login" && !router.pathname.startsWith("/reset") ?
                     <button onClick={logOut}>Log out</button> : router.pathname.startsWith("/reset") ?
                         <button onClick={logIn}>Log in</button> : null

--- a/frontend/contexts/sessionProvider.tsx
+++ b/frontend/contexts/sessionProvider.tsx
@@ -4,7 +4,8 @@ import React, {createContext, useEffect, useState} from 'react';
  * Interface for the context, stores the user session application wide
  */
 interface ISessionContext {
-    sessionKey: string;
+    sessionKey: string
+    getSessionKey?: () => string;
     setSessionKey?: (key: string) => void;
 
     isCoach: boolean;
@@ -45,6 +46,19 @@ export const SessionProvider: React.FC = ({ children }) => {
     const [isCoach, setIsCoachState] = useState<boolean>(false);
     const [isAdmin, setIsAdminState] = useState<boolean>(false);
 
+    /**
+     * The useEffect is not always called before other page's use effect
+     * Therefore we can use this function to get the sessionkey in the useEffect functions
+     */
+    const getSessionKey = () => {
+        if (sessionKey != undefined && sessionKey != "") {
+            return sessionKey
+        }
+
+        const key = localStorage.getItem('sessionKey')
+        return key !== null ? key : ""
+    }
+
     const setSessionKey = (sessionKey: string) => {
         setSessionKeyState(sessionKey)
         // Update localStorage
@@ -64,7 +78,7 @@ export const SessionProvider: React.FC = ({ children }) => {
     }
 
     return (
-        <SessionContext.Provider value={{sessionKey, setSessionKey, isCoach, setIsCoach, isAdmin, setIsAdmin}}>
+        <SessionContext.Provider value={{sessionKey, getSessionKey, setSessionKey, isCoach, setIsCoach, isAdmin, setIsAdmin}}>
             {children}
         </SessionContext.Provider>
     );

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -10,17 +10,21 @@ import {useRouter} from "next/router";
  */
 const Home: NextPage = () => {
 
-    const {sessionKey} = useContext(SessionContext)
+    const {getSessionKey} = useContext(SessionContext)
     const router = useRouter()
 
     useEffect(() => {
+        let sessionKey = ""
+        if (getSessionKey) {
+            sessionKey = getSessionKey()
+        }
         // No user is logged in
         if (sessionKey === "") {
             router.push("/login").then()
         } else {
             router.push("/students").then()
         }
-    }, [router, sessionKey])
+    }, [getSessionKey, router])
 
     return (<></>)
 }

--- a/frontend/pages/login/index.tsx
+++ b/frontend/pages/login/index.tsx
@@ -13,10 +13,14 @@ import SessionContext from "../../contexts/sessionProvider";
 const Index: NextPage = () => {
 
     const router = useRouter()
-    const {sessionKey, setSessionKey, setIsAdmin, setIsCoach} = useContext(SessionContext)
+    const {getSessionKey, setSessionKey, setIsAdmin, setIsCoach} = useContext(SessionContext)
 
     // Sets an error message when the `loginError` query paramater is present
     useEffect(() => {
+        let sessionKey = ""
+        if (getSessionKey) {
+            sessionKey = getSessionKey()
+        }
         // The user is already logged in, redirect the user
         if (sessionKey != "") {
             router.push("/students").then()
@@ -29,7 +33,7 @@ const Index: NextPage = () => {
                 setLoginBackendError(loginError)
             }
         }
-    }, [router, router.query, sessionKey])
+    }, [getSessionKey, router, router.query])
 
     // Index field values with corresponding error messages
     const [loginEmail, setLoginEmail] = useState<string>("");


### PR DESCRIPTION
As described in #270 and in the updated code comments.
The `sessionKey` get's set in the `SessionProvider`'s `useEffect` but as it turns out the order of useEffects does not always follow the topological order causing the sessionKey to be undefined at times in the useEffect. See this stackoverflow post for more information. Closes #270 
https://stackoverflow.com/questions/58352375/what-is-the-correct-order-of-execution-of-useeffect-in-react-parent-and-child-co
