### PR TITLE
Remove signup artifact

### DIFF
--- a/backend/request.ts
+++ b/backend/request.ts
@@ -1,10 +1,10 @@
 import {account_status_enum} from '@prisma/client';
 import express from 'express';
+import * as validator from 'validator';
 
 import * as config from './config.json';
 import {Anything, InternalTypes, Requests} from './types';
 import {errors, getSessionKey} from './utility';
-import * as validator from 'validator';
 
 /**
  *  We use 3 types of requests: those requiring no special values, those
@@ -169,15 +169,14 @@ async function parseUpdateLoginUser(req: express.Request):
  */
 export async function parseLoginRequest(req: express.Request):
     Promise<Requests.Login> {
-  return hasFields(req, [ "name", "pass" ], types.neither)
-      .then(() => {
-        if(!validator.default.isEmail(req.body.name)) {
-          return rejector();
-        } else {
-          const email = validator.default.normalizeEmail(req.body.name).toString();
-          return Promise.resolve({name : email, pass : req.body.pass});
-        }
-      });
+  return hasFields(req, [ "name", "pass" ], types.neither).then(() => {
+    if (!validator.default.isEmail(req.body.name)) {
+      return rejector();
+    } else {
+      const email = validator.default.normalizeEmail(req.body.name).toString();
+      return Promise.resolve({name : email, pass : req.body.pass});
+    }
+  });
 }
 
 /**
@@ -243,21 +242,19 @@ export async function parseSuggestStudentRequest(req: express.Request):
  *  @returns A Promise resolving to the parsed data or rejecting with an
  * Argument or Unauthenticated error.
  */
-export async function parseGetSuggestionsStudentRequest(req: express.Request): Promise<Requests.YearId> {
+export async function parseGetSuggestionsStudentRequest(req: express.Request):
+    Promise<Requests.YearId> {
   return hasFields(req, [], types.id).then(() => {
-    if("year" in req.body) {
+    if ("year" in req.body) {
       return Promise.resolve({
         sessionkey : getSessionKey(req),
         id : Number(req.params.id),
         year : Number(req.body.year)
       });
     } else {
-      return Promise.resolve({
-        sessionkey : getSessionKey(req),
-        id : Number(req.params.id)
-      });
+      return Promise.resolve(
+          {sessionkey : getSessionKey(req), id : Number(req.params.id)});
     }
-
   });
 }
 
@@ -267,22 +264,27 @@ export async function parseGetSuggestionsStudentRequest(req: express.Request): P
  *  @returns A Promise resolving to the parsed data or rejecting with an
  * Argument or Unauthenticated error.
  */
-export async function parseFilterStudentsRequest(req: express.Request): Promise<Requests.StudentFilter> {
-  if(("emailFilter" in req.body && !validator.default.isEmail(req.body.emailFilter)) ||
-      ("statusFilter" in req.body && req.body.statusFilter !== "YES" && req.body.statusFilter !== "MAYBE" &&
-          req.body.statusFilter !== "NO")) {
+export async function parseFilterStudentsRequest(req: express.Request):
+    Promise<Requests.StudentFilter> {
+  if (("emailFilter" in req.body &&
+       !validator.default.isEmail(req.body.emailFilter)) ||
+      ("statusFilter" in req.body && req.body.statusFilter !== "YES" &&
+       req.body.statusFilter !== "MAYBE" && req.body.statusFilter !== "NO")) {
     console.log("test1");
     return rejector();
   } else {
     console.log("test2");
-    if("emailFilter" in req.body) {
-      req.body.emailFilter = validator.default.normalizeEmail(req.body.emailFilter).toString();
+    if ("emailFilter" in req.body) {
+      req.body.emailFilter =
+          validator.default.normalizeEmail(req.body.emailFilter).toString();
     }
   }
 
-  for(const filter of [maybe(req.body, "firstNameSort"), maybe(req.body, "lastNameSort"),
-    maybe(req.body, "emailSort"), maybe(req.body, "roleSort"), maybe(req.body, "alumniSort")]) {
-    if(filter != undefined && filter !== "asc" && filter !== "desc") {
+  for (const filter
+           of [maybe(req.body, "firstNameSort"),
+               maybe(req.body, "lastNameSort"), maybe(req.body, "emailSort"),
+               maybe(req.body, "roleSort"), maybe(req.body, "alumniSort")]) {
+    if (filter != undefined && filter !== "asc" && filter !== "desc") {
       return rejector();
     }
   }
@@ -336,13 +338,13 @@ export async function parseFinalizeDecisionRequest(req: express.Request):
  */
 export async function parseRequestCoachRequest(req: express.Request):
     Promise<Requests.CoachRequest> {
-  return hasFields(req, [ "firstName", "lastName", "emailOrGithub" ],
+  return hasFields(req, [ "firstName", "lastName", "email", "pass" ],
                    types.neither)
       .then(() => Promise.resolve({
         firstName : req.body.firstName,
         lastName : req.body.lastName,
-        emailOrGithub : req.body.emailOrGithub,
-        pass : maybe(req.body, "pass")
+        email : req.body.email,
+        pass : req.body.pass
       }));
 }
 
@@ -601,7 +603,7 @@ export const parseDeleteStudentRequest = parseKeyIdRequest;
  * ID
  * {@link parseKeyIdRequest}.
  */
-//export const parseStudentGetSuggestsRequest = parseKeyIdRequest;
+// export const parseStudentGetSuggestsRequest = parseKeyIdRequest;
 /**
  *  A request to `GET /coach/<id>` only requires a session key and an ID
  * {@link parseKeyIdRequest}.

--- a/backend/routes/coach.ts
+++ b/backend/routes/coach.ts
@@ -14,23 +14,26 @@ import * as util from '../utility';
  * `Promise.resolve`, failures using `Promise.reject`.
  */
 async function listCoaches(req: express.Request): Promise<Responses.CoachList> {
-    return rq.parseCoachAllRequest(req)
-        .then(parsed => util.checkSessionKey(parsed))
-        .then(
-            async parsed =>
-                ormLU.searchAllCoachLoginUsers(true)
-                    .then(obj =>
-                        obj.map(val => ({
-                            person_data : {
-                                id : val.person.person_id,
-                                name : val.person.firstname + " " + val.person.lastname,
-                                email: val.person.email
-                            },
-                            coach : val.is_coach,
-                            admin : val.is_admin,
-                            activated : val.account_status as string
-                        })))
-                    .then(obj => Promise.resolve({sessionkey : parsed.data.sessionkey, data : obj})));
+  return rq.parseCoachAllRequest(req)
+      .then(parsed => util.checkSessionKey(parsed))
+      .then(
+          async parsed =>
+              ormLU.searchAllCoachLoginUsers(true)
+                  .then(obj =>
+                            obj.map(val => ({
+                                      person_data : {
+                                        id : val.person.person_id,
+                                        name : val.person.firstname + " " +
+                                                   val.person.lastname,
+                                        email : val.person.email
+                                      },
+                                      coach : val.is_coach,
+                                      admin : val.is_admin,
+                                      activated : val.account_status as string
+                                    })))
+                  .then(
+                      obj => Promise.resolve(
+                          {sessionkey : parsed.data.sessionkey, data : obj})));
 }
 
 /**
@@ -138,7 +141,7 @@ async function createCoachRequest(req: express.Request):
         .createPerson({
           firstname : parsed.firstName,
           lastname : parsed.lastName,
-          email : parsed.emailOrGithub
+          email : parsed.email
         })
         .then(person => {
           console.log("Created a person: " + person);

--- a/backend/types.ts
+++ b/backend/types.ts
@@ -132,7 +132,7 @@ export interface User {}
 /**
  *  Represents a check of the key, holds the key aswell as boolean value.
  */
- export interface CheckKey {}
+export interface CheckKey {}
 
 /**
  *  Represents a coach, with all associated data.
@@ -362,11 +362,11 @@ export interface ProjectDraftedStudents extends
 export interface ModProjectStudent extends
     Keyed<InternalTypes.ModProjectStudent> {}
 
-  /**
-   *  A studentList response is the keyed version of a list of students and their
-   * associated data.
-   */
-  export interface StudentList extends Keyed<InternalTypes.Student[]> {}
+/**
+ *  A studentList response is the keyed version of a list of students and their
+ * associated data.
+ */
+export interface StudentList extends Keyed<InternalTypes.Student[]> {}
 
 /**
  *  @deprecated Either an API Error or a data value. Is deprecated in favor of
@@ -386,7 +386,7 @@ export interface FormResponse<T> {
   /**
    *  The data.
    */
-  data: T | null;
+  data: T|null;
 }
 }
 
@@ -451,8 +451,8 @@ export interface UpdateLoginUser extends IdRequest {
 export interface CoachRequest {
   firstName: string;
   lastName: string;
-  emailOrGithub: string;
-  pass?: string;
+  email: string;
+  pass: string;
 }
 
 export interface Project extends KeyRequest {
@@ -505,7 +505,6 @@ export interface Form {
 export interface Role extends KeyRequest {
   name: string
 }
-
 
 export interface DataForm {
   fields: Array<Question>

--- a/frontend/pages/login/index.tsx
+++ b/frontend/pages/login/index.tsx
@@ -231,7 +231,7 @@ const Index: NextPage = () => {
                 body: JSON.stringify({
                     firstName: registerFirstName,
                     lastName: registerLastName,
-                    emailOrGithub: registerEmail,
+                    email: registerEmail,
                     pass: encryptedPassword
                 }),
                 headers: {


### PR DESCRIPTION
`POST /coach/request` used `emailOrGithub` as a field. This has been changed to `email` because GitHub signin/register is in an entirely separate route. (Modified the calling code in de FE as well).

⚠️ **BREAKING CHANGES** ⚠️ 
`POST /coach/request` doesn't take `emailOrGithub` anymore. Use `email` instead.