### PR TITLE
fix: unify first name and last name in a single field

### DIFF
--- a/backend/request.ts
+++ b/backend/request.ts
@@ -456,17 +456,14 @@ export async function parseFinalizeDecisionRequest(
 export async function parseRequestUserRequest(
     req: express.Request
 ): Promise<Requests.UserRequest> {
-    return hasFields(
-        req,
-        ["firstName", "lastName", "email", "pass"],
-        types.neither
-    ).then(() =>
-        Promise.resolve({
-            firstName: req.body.firstName,
-            lastName: req.body.lastName,
-            email: req.body.email,
-            pass: req.body.pass,
-        })
+    return hasFields(req, ["firstName", "email", "pass"], types.neither).then(
+        () =>
+            Promise.resolve({
+                firstName: req.body.firstName,
+                lastName: "",
+                email: req.body.email,
+                pass: req.body.pass,
+            })
     );
 }
 

--- a/backend/routes/user.ts
+++ b/backend/routes/user.ts
@@ -61,7 +61,7 @@ async function createUserRequest(
         return ormP
             .createPerson({
                 firstname: parsed.firstName,
-                lastname: parsed.lastName,
+                lastname: "",
                 email: validator.default
                     .normalizeEmail(parsed.email)
                     .toString(),

--- a/backend/tests/request.test.ts
+++ b/backend/tests/request.test.ts
@@ -205,8 +205,8 @@ test("Can parse update student request", () => {
     const dataV: T.Anything = {
         emailOrGithub: "ab@c.de",
         alumni: false,
-        firstName: "ab",
-        lastName: "c",
+        firstName: "ab c",
+        lastName: "",
         gender: "Apache Attack Helicopter",
         pronouns: "vroom/vroom",
         phone: "+32420 696969",
@@ -235,8 +235,8 @@ test("Can parse update student request", () => {
 
     const failure2: T.Anything = {
         emailOrGithub: "ab@c.de",
-        firstName: "ab",
-        lastName: "c",
+        firstName: "ab c",
+        lastName: "",
         gender: "Apache Attack Helicopter",
         pronouns: "vroom/vroom",
         phone: "+32420 696969",
@@ -401,15 +401,15 @@ test("Can parse final decision request", () => {
 
 test("Can parse coach access request", () => {
     const r1: T.Anything = {
-        firstName: "Jeff",
-        lastName: "Georgette",
+        firstName: "Jeff Georgette",
+        lastName: "",
         email: "idonthavegithub@git.hub",
         pass: "thisismypassword",
     };
 
     const r2: T.Anything = {
-        firstName: "Jeff",
-        lastName: "Georgette",
+        firstName: "Jeff Georgette",
+        lastName: "",
         email: "idonthavegithub@git.hub",
     };
 

--- a/frontend/components/Footer/Footer.module.css
+++ b/frontend/components/Footer/Footer.module.css
@@ -1,6 +1,6 @@
 .footer {
     background-color: var(--neutral-150);
-    min-height: clamp(4rem, 10vw, 6rem);
+    min-height: clamp(2rem, 10vw, 4rem);
     padding-block: 0.5rem;
     padding-inline: min(8rem, 16vw);
     display: flex;

--- a/frontend/pages/login/index.tsx
+++ b/frontend/pages/login/index.tsx
@@ -47,12 +47,8 @@ const Index: NextPage = () => {
     // Register field values with corresponding error messages
     const [registerEmail, setRegisterEmail] = useState<string>("");
     const [registerEmailError, setRegisterEmailError] = useState<string>("");
-    const [registerFirstName, setRegisterFirstName] = useState<string>("");
-    const [registerFirstNameError, setRegisterFirstNameError] =
-        useState<string>("");
-    const [registerLastName, setRegisterLastName] = useState<string>("");
-    const [registerLastNameError, setRegisterLastNameError] =
-        useState<string>("");
+    const [registerName, setRegisterName] = useState<string>("");
+    const [registerNameError, setRegisterNameError] = useState<string>("");
     const [registerPassword, setRegisterPassword] = useState<string>("");
     const [registerPasswordError, setRegisterPasswordError] =
         useState<string>("");
@@ -217,18 +213,11 @@ const Index: NextPage = () => {
             setRegisterEmailError("");
         }
 
-        if (registerFirstName === "") {
-            setRegisterFirstNameError("First name cannot be empty");
+        if (registerName === "") {
+            setRegisterNameError("Name cannot be empty");
             error = true;
         } else {
-            setRegisterFirstNameError("");
-        }
-
-        if (registerLastName === "") {
-            setRegisterLastNameError("Last name cannot be empty");
-            error = true;
-        } else {
-            setRegisterLastNameError("");
+            setRegisterNameError("");
         }
 
         if (registerPassword === "") {
@@ -262,11 +251,7 @@ const Index: NextPage = () => {
                 {
                     method: "POST",
                     body: JSON.stringify({
-                        firstName: (
-                            registerFirstName +
-                            " " +
-                            registerLastName
-                        ).trim(),
+                        firstName: registerName.trim(),
                         email: registerEmail,
                         pass: encryptedPassword,
                     }),
@@ -483,40 +468,22 @@ const Index: NextPage = () => {
                         }}
                     >
                         <label className={styles.label}>
-                            First Name
+                            Name
                             <input
                                 type="text"
-                                name="registerFirstName"
-                                value={registerFirstName}
+                                name="registerName"
+                                value={registerName}
                                 onChange={(e) =>
-                                    setRegisterFirstName(e.target.value)
+                                    setRegisterName(e.target.value)
                                 }
                             />
                         </label>
                         <p
                             className={`${styles.textFieldError} ${
-                                registerFirstNameError !== "" ? styles.anim : ""
+                                registerNameError !== "" ? styles.anim : ""
                             }`}
                         >
-                            {registerFirstNameError}
-                        </p>
-                        <label className={styles.label}>
-                            Last Name
-                            <input
-                                type="text"
-                                name="registerLastName"
-                                value={registerLastName}
-                                onChange={(e) =>
-                                    setRegisterLastName(e.target.value)
-                                }
-                            />
-                        </label>
-                        <p
-                            className={`${styles.textFieldError} ${
-                                registerLastNameError !== "" ? styles.anim : ""
-                            }`}
-                        >
-                            {registerLastNameError}
+                            {registerNameError}
                         </p>
                         <label className={styles.label}>
                             Email


### PR DESCRIPTION
We no longer make a distinction between first name and last name for users.
(Mainly because GitHub login doesn't, so we like to keep things uniform)

This PR makes the First Name and Last Name a single Name field.

**Note:** Registration does is bugged at the time of writing, see #401

![image](https://user-images.githubusercontent.com/56763273/164709786-0278b09c-e145-4790-91dd-b6899c86da8f.png)
