### PR TITLE
fix: no longer self-host github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,8 +17,7 @@ updates:
     # Set the target branch to `development` instead of default `main`
     target-branch: "development"
     assignees:
-      - "BramDevlaminck"
-      - "Jonathan-Vanbrabant"
+      - "SELab-2/osoc-team2"
     commit-message:
       prefix: "npm-root"
       include: "scope"
@@ -39,8 +38,7 @@ updates:
     # Set the target branch to `development` instead of default `main`
     target-branch: "development"
     assignees:
-      - "BramDevlaminck"
-      - "Jonathan-Vanbrabant"
+      - "SELab-2/osoc-team2"
     commit-message:
       prefix: "npm-frontend"
       include: "scope"
@@ -61,8 +59,7 @@ updates:
     # Set the target branch to `development` instead of default `main`
     target-branch: "development"
     assignees:
-      - "BramDevlaminck"
-      - "Jonathan-Vanbrabant"
+      - "SELab-2/osoc-team2"
     commit-message:
       prefix: "npm-backend"
       include: "scope"
@@ -83,8 +80,7 @@ updates:
     # Set the target branch to `development` instead of default `main`
     target-branch: "development"
     assignees:
-      - "BramDevlaminck"
-      - "Jonathan-Vanbrabant"
+      - "SELab-2/osoc-team2"
     commit-message:
       prefix: "docker-backend"
       include: "scope"
@@ -105,8 +101,7 @@ updates:
     # Set the target branch to `development` instead of default `main`
     target-branch: "development"
     assignees:
-      - "BramDevlaminck"
-      - "Jonathan-Vanbrabant"
+      - "SELab-2/osoc-team2"
     commit-message:
       prefix: "docker-database"
       include: "scope"
@@ -127,8 +122,7 @@ updates:
     # Set the target branch to `development` instead of default `main`
     target-branch: "development"
     assignees:
-      - "BramDevlaminck"
-      - "Jonathan-Vanbrabant"
+      - "SELab-2/osoc-team2"
     commit-message:
       prefix: "docker-frontend"
       include: "scope"
@@ -150,12 +144,9 @@ updates:
     # Set the target branch to `development` instead of default `main`
     target-branch: "development"
     assignees:
-      - "BramDevlaminck"
-      - "Jonathan-Vanbrabant"
-      - "HuanYu-Tan"
+      - "SELab-2/osoc-team2"
     commit-message:
       prefix: "github-actions"
       include: "scope"
     labels:
       - "CI/CD"
-

--- a/.github/workflows/backendCI.yml
+++ b/.github/workflows/backendCI.yml
@@ -12,7 +12,7 @@ on:
   
 jobs:
   ci:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     
     services:
      postgres: # this is for the integration testing of the orm functions

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   ci:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js 17.x

--- a/.github/workflows/frontendCI.yml
+++ b/.github/workflows/frontendCI.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   ci:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js 17.x


### PR DESCRIPTION
We are public!!

This means we can make unlimited use of GitHub's own actions runners.
