### PR TITLE
IO-emit remove

### DIFF
--- a/backend/index.ts
+++ b/backend/index.ts
@@ -26,7 +26,7 @@ require("dotenv").config({
     path: path.join(__dirname, `./.env.${process.env.NODE_ENV}`),
 });
 
-export const io = new Server<
+const io = new Server<
     ClientToServerEvents,
     ServerToClientEvents,
     InterServerEvents,

--- a/backend/routes/form.ts
+++ b/backend/routes/form.ts
@@ -17,7 +17,6 @@ import { type_enum } from "@prisma/client";
 import * as validator from "validator";
 import * as rq from "../request";
 import * as config from "./form_keys.json";
-import { io } from "../index";
 
 /**
  *  This function searches a question with a given key in the form.
@@ -1510,7 +1509,6 @@ async function createForm(req: express.Request): Promise<Responses.Empty> {
         await addRolesToDatabase(roles, {
             id: addedJobApplicationToDatabase.id,
         });
-        io.emit("formAdded");
         return Promise.resolve({});
     }
 

--- a/backend/types.ts
+++ b/backend/types.ts
@@ -888,7 +888,6 @@ export interface Email {
  * types for socket.io when sending something from the server to the client
  */
 export interface ServerToClientEvents {
-    formAdded: () => void;
     loginUserUpdated: () => void;
 }
 

--- a/frontend/pages/students.tsx
+++ b/frontend/pages/students.tsx
@@ -4,12 +4,10 @@ import { useContext, useEffect, useState } from "react";
 import { StudentCard } from "../components/StudentCard/StudentCard";
 import { Student } from "../types";
 import styles from "../styles/students.module.scss";
-import { useSockets } from "../contexts/socketProvider";
 
 const Students: NextPage = () => {
     const { getSessionKey } = useContext(SessionContext);
     const [students, setStudents] = useState<Student[]>([]);
-    const { socket } = useSockets();
 
     const fetchStudents = async () => {
         if (getSessionKey !== undefined) {
@@ -36,19 +34,8 @@ const Students: NextPage = () => {
 
     useEffect(() => {
         fetchStudents().then();
-        return () => {
-            socket.off("formAdded");
-        }; // disconnect from the socket on dismount
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
-
-    useEffect(() => {
-        socket.on("formAdded", () => {
-            fetchStudents().then();
-        });
-
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [socket]);
 
     return (
         <div className={styles.students}>

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -166,7 +166,6 @@ export interface LoginUser {
  * types for socket.io when sending something from the server to the client
  */
 export interface ServerToClientEvents {
-    formAdded: () => void;
     loginUserUpdated: () => void;
 }
 


### PR DESCRIPTION
remove io.emit from websockets when new form was added.

This was unnecessary because the process of filtering only starts when the forms are closed (no new entries).
It also created an ugly export and extra difficulty when testing => just remove it.