### PR TITLE
Pending redirect

### DIFF
--- a/docs/API/api.json
+++ b/docs/API/api.json
@@ -2579,7 +2579,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/UserId"
+                  "$ref": "#/components/schemas/RegisterResponse"
                 }
               }
             }
@@ -3783,11 +3783,14 @@
           "name": "Create_template"
         }
       },
-      "UserId": {
+      "RegisterResponse": {
         "type": "object",
         "properties": {
           "id": {
             "type": "number"
+          },
+          "sessionKey" : {
+            "type" : "string"
           }
         },
         "xml": {

--- a/frontend/contexts/sessionProvider.tsx
+++ b/frontend/contexts/sessionProvider.tsx
@@ -106,6 +106,7 @@ export const SessionProvider: React.FC<{ children: ReactNode }> = ({
                     return "";
                 }
                 if (response.account_status === AccountStatus.PENDING) {
+                    verified = false;
                     router.push("/pending");
                     return "";
                 }

--- a/frontend/contexts/sessionProvider.tsx
+++ b/frontend/contexts/sessionProvider.tsx
@@ -106,7 +106,7 @@ export const SessionProvider: React.FC<{ children: ReactNode }> = ({
                     return "";
                 }
                 if (response.account_status === AccountStatus.PENDING) {
-                    verified = false;
+                    verified = false; // needs to be false, otherwise the next request will think it's automatically true, even when it has an invalid key.
                     router.push("/pending");
                     return "";
                 }

--- a/frontend/contexts/sessionProvider.tsx
+++ b/frontend/contexts/sessionProvider.tsx
@@ -42,6 +42,7 @@ export const SessionProvider: React.FC<{ children: ReactNode }> = ({
 
     // Because `useEffect` can have a different order we need to check if the session id has already been verified
     let verified = false;
+    let pendingChecked = false;
 
     /**
      * Everytime the page is reloaded we need to get the session from local storage
@@ -76,6 +77,12 @@ export const SessionProvider: React.FC<{ children: ReactNode }> = ({
             return sessionKey;
         }
 
+        // we already did a request, and we know we are pending (key is invalid) => go to pending
+        if (pendingChecked) {
+            router.push("/pending").then();
+            return "";
+        }
+
         // Avoid calling /verify twice
         // verified gets set to false every page reload
         if (verified) {
@@ -106,7 +113,7 @@ export const SessionProvider: React.FC<{ children: ReactNode }> = ({
                     return "";
                 }
                 if (response.account_status === AccountStatus.PENDING) {
-                    verified = false; // needs to be false, otherwise the next request will think it's automatically true, even when it has an invalid key.
+                    pendingChecked = true; // needs to be false, otherwise the next request will think it's automatically true, even when it has an invalid key.
                     router.push("/pending");
                     return "";
                 }

--- a/frontend/contexts/sessionProvider.tsx
+++ b/frontend/contexts/sessionProvider.tsx
@@ -113,7 +113,7 @@ export const SessionProvider: React.FC<{ children: ReactNode }> = ({
                     return "";
                 }
                 if (response.account_status === AccountStatus.PENDING) {
-                    pendingChecked = true; // needs to be false, otherwise the next request will think it's automatically true, even when it has an invalid key.
+                    pendingChecked = true; // otherwise the next request will think it's automatically true, even when it has an invalid key.
                     router.push("/pending");
                     return "";
                 }

--- a/frontend/pages/login/index.tsx
+++ b/frontend/pages/login/index.tsx
@@ -281,6 +281,9 @@ const Index: NextPage = () => {
                 });
 
             if (response.success) {
+                if (setSessionKey) {
+                    setSessionKey(response.sessionkey);
+                }
                 await router.push("/pending");
             }
         }

--- a/frontend/pages/pending.tsx
+++ b/frontend/pages/pending.tsx
@@ -1,10 +1,28 @@
 import { NextPage } from "next";
 import styles from "../styles/pending.module.scss";
+import { useContext, useEffect } from "react";
+import SessionContext from "../contexts/sessionProvider";
+import { useRouter } from "next/router";
 
 /**
  * Will be shown to every user that is not yet accepted by an admin
  */
 const Pending: NextPage = () => {
+    const router = useRouter();
+    const { getSessionKey } = useContext(SessionContext);
+    // check if user is logged in, if the user is logged in, redirect away from this page
+    useEffect(() => {
+        if (getSessionKey) {
+            getSessionKey().then((sessionKey) => {
+                // The user is already logged in, redirect the user
+                if (sessionKey != "") {
+                    router.push("/students").then();
+                }
+            });
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
     return (
         <div>
             <h2 className={styles.pending}>


### PR DESCRIPTION
closes #437 

When your account is not pending anymore, you should redirect away from pending to `/student`. I've implemented this now.

To do this I had to return the session key from the backend when loggin in. 

Question for @Mouwrice:
in `sessionProvider` on line `109` I had to put this `verified` boolean on false.
this fixes all the redirects with an invalid key but everything now runs twice. I don't quite understand why and how I should solve this. From the comments I understand it has to do with `useEffect`?