### PR TITLE
fix: the header links now only show when the user has been verified

### DIFF
--- a/frontend/components/Header/Header.tsx
+++ b/frontend/components/Header/Header.tsx
@@ -14,6 +14,7 @@ export const Header: React.FC = () => {
         isAdmin,
         setIsAdmin,
         setIsCoach,
+        setIsVerified,
     } = useContext(SessionContext);
 
     const router = useRouter();
@@ -33,6 +34,9 @@ export const Header: React.FC = () => {
         }
         if (setIsCoach) {
             setIsCoach(false);
+        }
+        if (setIsVerified) {
+            setIsVerified(false);
         }
         router.push("/login").then(() => {
             // After being redirected to the login page, let the backend now that the user has logged out.
@@ -85,9 +89,10 @@ export const Header: React.FC = () => {
                 !router.pathname.startsWith("/reset") ? (
                     <Link href={"/users"}>Manage Users</Link>
                 ) : null}
-                {isVerified &&
-                router.pathname !== "/login" &&
-                !router.pathname.startsWith("/reset") ? (
+                {(isVerified &&
+                    router.pathname !== "/login" &&
+                    !router.pathname.startsWith("/reset")) ||
+                router.pathname.startsWith("/pending") ? (
                     <button onClick={logOut}>Log out</button>
                 ) : isVerified && router.pathname.startsWith("/reset") ? (
                     <button onClick={logIn}>Log in</button>

--- a/frontend/components/Header/Header.tsx
+++ b/frontend/components/Header/Header.tsx
@@ -2,14 +2,14 @@ import styles from "./Header.module.css";
 import Image from "next/image";
 import LogoOsocColor from "../../public/images/logo-osoc-color.svg";
 import Link from "next/link";
-import React, { SyntheticEvent, useContext, useEffect, useState } from "react";
+import React, { SyntheticEvent, useContext } from "react";
 import SessionContext from "../../contexts/sessionProvider";
 import { useRouter } from "next/router";
 
 export const Header: React.FC = () => {
     const {
         sessionKey,
-        getSessionKey,
+        isVerified,
         setSessionKey,
         isAdmin,
         setIsAdmin,
@@ -17,20 +17,6 @@ export const Header: React.FC = () => {
     } = useContext(SessionContext);
 
     const router = useRouter();
-    const [validUser, setValidUser] = useState<boolean>(false);
-
-    useEffect(() => {
-        if (getSessionKey) {
-            getSessionKey().then(async (sessionKey) => {
-                if (sessionKey !== "") {
-                    setValidUser(true);
-                } else {
-                    setValidUser(false);
-                }
-            });
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
 
     const logIn = (e: SyntheticEvent) => {
         e.preventDefault();
@@ -84,24 +70,26 @@ export const Header: React.FC = () => {
                     router.pathname !== "/login" ? "" : styles.displayNone
                 }`}
             >
-                {validUser && !router.pathname.startsWith("/reset") ? (
+                {isVerified && !router.pathname.startsWith("/reset") ? (
                     <Link href={"/students"}>Students</Link>
                 ) : null}
-                {validUser && !router.pathname.startsWith("/reset") ? (
+                {isVerified && !router.pathname.startsWith("/reset") ? (
                     <Link href={"/projects"}>Projects</Link>
                 ) : null}
-                {validUser && !router.pathname.startsWith("/reset") ? (
+                {isVerified && !router.pathname.startsWith("/reset") ? (
                     <Link href={"/osocs"}>Osoc Editions</Link>
                 ) : null}
                 {sessionKey !== "" &&
+                isVerified &&
                 isAdmin &&
                 !router.pathname.startsWith("/reset") ? (
                     <Link href={"/users"}>Manage Users</Link>
                 ) : null}
-                {router.pathname !== "/login" &&
+                {isVerified &&
+                router.pathname !== "/login" &&
                 !router.pathname.startsWith("/reset") ? (
                     <button onClick={logOut}>Log out</button>
-                ) : router.pathname.startsWith("/reset") ? (
+                ) : isVerified && router.pathname.startsWith("/reset") ? (
                     <button onClick={logIn}>Log in</button>
                 ) : null}
             </div>

--- a/frontend/contexts/sessionProvider.tsx
+++ b/frontend/contexts/sessionProvider.tsx
@@ -14,6 +14,8 @@ interface ISessionContext {
     setIsCoach?: (coach: boolean) => void;
     isAdmin: boolean;
     setIsAdmin?: (admin: boolean) => void;
+    /* Boolean that is true when the user has been verified */
+    isVerified: boolean;
 }
 
 // The default state the application is in
@@ -21,6 +23,7 @@ const defaultState = {
     sessionKey: "", // No user is logged in
     isCoach: false,
     isAdmin: false,
+    isVerified: false,
 };
 
 const SessionContext = createContext<ISessionContext>(defaultState);
@@ -39,6 +42,7 @@ export const SessionProvider: React.FC<{ children: ReactNode }> = ({
     const [sessionKey, setSessionKeyState] = useState<string>("");
     const [isCoach, setIsCoachState] = useState<boolean>(false);
     const [isAdmin, setIsAdminState] = useState<boolean>(false);
+    const [isVerified, setIsVerified] = useState<boolean>(false);
 
     // Because `useEffect` can have a different order we need to check if the session id has already been verified
     let verified = false;
@@ -129,6 +133,7 @@ export const SessionProvider: React.FC<{ children: ReactNode }> = ({
                     return "";
                 }
                 setSessionKey(sessionKey);
+                setIsVerified(true);
                 return sessionKey;
             })
             .catch((error) => {
@@ -139,6 +144,7 @@ export const SessionProvider: React.FC<{ children: ReactNode }> = ({
                     router.push("/login");
                 }
                 setSessionKey("");
+                setIsVerified(true);
                 return "";
             });
     };
@@ -171,6 +177,7 @@ export const SessionProvider: React.FC<{ children: ReactNode }> = ({
                 setIsCoach,
                 isAdmin,
                 setIsAdmin,
+                isVerified,
             }}
         >
             {children}

--- a/frontend/contexts/sessionProvider.tsx
+++ b/frontend/contexts/sessionProvider.tsx
@@ -16,6 +16,7 @@ interface ISessionContext {
     setIsAdmin?: (admin: boolean) => void;
     /* Boolean that is true when the user has been verified */
     isVerified: boolean;
+    setIsVerified?: (verified: boolean) => void;
 }
 
 // The default state the application is in
@@ -178,6 +179,7 @@ export const SessionProvider: React.FC<{ children: ReactNode }> = ({
                 isAdmin,
                 setIsAdmin,
                 isVerified,
+                setIsVerified,
             }}
         >
             {children}


### PR DESCRIPTION
The header would show the buttons / links when a sessionkey is present in the localStorage. This sessionkey has to be valid ofcourse so I added the `isVerified` state to the SessionProvider, which we can use to show when the sessionkey has been verified. Only verified users will see the buttons from now.
