### PR TITLE
Error in `POST /user/self`

### DIFF
--- a/backend/routes/user.ts
+++ b/backend/routes/user.ts
@@ -285,7 +285,7 @@ export async function userModSelf(
     return rq
         .parseUserModSelfRequest(req)
         .then((parsed) => util.checkSessionKey(parsed, false))
-        .then((checked) => {
+        .then(async (checked) => {
             return ormLU
                 .getLoginUserById(checked.userId)
                 .then((user) => util.getOrReject(user))
@@ -304,7 +304,10 @@ export async function userModSelf(
                     }
                     // the old password to compare to was not as expected => return error
                     if (!valid) {
-                        return Promise.reject();
+                        return Promise.reject({
+                            http: 409,
+                            reason: "Old password is incorrect. Didn't update password.",
+                        });
                     }
                     return Promise.resolve(user);
                 })
@@ -333,7 +336,7 @@ export async function userModSelf(
                     return Promise.resolve(user);
                 })
                 .then((user) => Promise.resolve(user.person))
-                .then((person) => {
+                .then(async (person) => {
                     if (checked.data.name != undefined) {
                         return ormP
                             .updatePerson({
@@ -346,7 +349,7 @@ export async function userModSelf(
                 })
                 .then(() => Promise.resolve(checked));
         })
-        .then((checked) => {
+        .then(async (checked) => {
             if (checked.data.pass == undefined) {
                 return Promise.resolve({ sessionkey: checked.data.sessionkey });
             }


### PR DESCRIPTION
Fixes #545 

**The Bug**  
When attempting to modify one's own password, passing an invalid *old* password caused an `undefined` error (cause by a `Promise.reject()`). This came to the frontend as an HTTP 500.

**The Solution**  
When the *old* password is invalid, the backend will reply with an `HTTP 409 Conflict` response (with the reason `Old password is incorrect. Didn't update password.`).

(Additionally, I made some arrow functions async as my in-editor linter was complaining 🤷🏻).