### PR TITLE
GitHub additional data

### DIFF
--- a/backend/routes/github.ts
+++ b/backend/routes/github.ts
@@ -48,11 +48,9 @@ export function genState(redirect: string): string {
  */
 export function checkState(state: string): string | false {
     if (!(state in states)) {
-        // if (!states.includes(state)) {
         return false;
     }
 
-    // states = states.filter((x) => x != state);
     const frontend = states[state];
     delete states[state];
     return frontend;
@@ -76,7 +74,6 @@ export function ghIdentity(
         "callback" in req.body
             ? (req.body.callback as string)
             : (process.env.FRONTEND as string);
-    console.log("Client requested frontend " + frontend);
     let url = "https://github.com/login/oauth/authorize?";
     url += "client_id=" + process.env.GITHUB_CLIENT_ID; // add client id
     url += "&allow_signup=true"; // allow users to sign up to github itself
@@ -138,7 +135,6 @@ export async function ghExchangeAccessToken(
                 result.sessionkey +
                 "?is_signup=" +
                 result.is_signup;
-            console.log("Redirecting towards FE " + url);
             return util.redirect(res, url);
         })
         .catch((err) => {

--- a/backend/routes/github.ts
+++ b/backend/routes/github.ts
@@ -119,7 +119,11 @@ export async function ghExchangeAccessToken(
         .then((result) =>
             util.redirect(
                 res,
-                process.env.FRONTEND + "/login/" + result.sessionkey
+                process.env.FRONTEND +
+                    "/login/" +
+                    result.sessionkey +
+                    "?is_signup=" +
+                    result.is_signup
             )
         )
         .catch((err) => {
@@ -183,7 +187,8 @@ export function githubNameChange(
  */
 export async function ghSignupOrLogin(
     login: Requests.GHLogin
-): Promise<Responses.Login> {
+): Promise<Responses.GithubLogin> {
+    let isSignup = false;
     return ormP
         .getPasswordPersonByGithub(login.id)
         .then(async (person) => {
@@ -206,6 +211,7 @@ export async function ghSignupOrLogin(
         })
         .catch(async (error) => {
             if ("is_not_existent" in error && error.is_not_existent) {
+                isSignup = true;
                 return ormP
                     .createPerson({
                         github: login.login,
@@ -246,6 +252,7 @@ export async function ghSignupOrLogin(
                         sessionkey: newkey.session_key,
                         is_admin: loginuser.is_admin,
                         is_coach: loginuser.is_coach,
+                        is_signup: isSignup,
                     })
                 );
         });

--- a/backend/tests/routes_unit/github.test.ts
+++ b/backend/tests/routes_unit/github.test.ts
@@ -127,12 +127,14 @@ function expectNoCall<T>(func: T) {
 }
 
 test("Can generate and validate states", () => {
-    expect(github.checkState(github.genState())).toBe(true);
+    expect(
+        github.checkState(github.genState(process.env.FRONTEND as string))
+    ).toBe(process.env.FRONTEND as string);
 });
 
 test("A state is valid only once", () => {
-    const state = github.genState();
-    expect(github.checkState(state)).toBe(true);
+    const state = github.genState(process.env.FRONTEND as string);
+    expect(github.checkState(state)).toBe(process.env.FRONTEND as string);
     expect(github.checkState(state)).toBe(false);
 });
 
@@ -144,10 +146,10 @@ test("ghIdentity correctly redirects", async () => {
         "state=";
     utilMock.redirect.mockReset();
     utilMock.redirect.mockImplementation(async (_, url) => {
-        expect(url).toBe(exp + github.states[0]);
+        expect(url).toBe(exp + Object.keys(github.states)[0]);
     });
 
-    await github.ghIdentity(getMockRes().res);
+    await github.ghIdentity(getMockReq(), getMockRes().res);
 });
 
 test("Can parse GH login", async () => {
@@ -383,7 +385,10 @@ test("Can exchange access token for session key", async () => {
 
     const req = getMockReq();
     const res = getMockRes().res;
-    req.query = { code: code, state: github.genState() };
+    req.query = {
+        code: code,
+        state: github.genState(process.env.FRONTEND as string),
+    };
     return expect(
         github.ghExchangeAccessToken(req, res)
     ).resolves.not.toThrow();
@@ -403,7 +408,10 @@ test("Can handle internet issues", async () => {
 
     const req = getMockReq();
     const res = getMockRes().res;
-    req.query = { code: "code", state: github.genState() };
+    req.query = {
+        code: "code",
+        state: github.genState(process.env.FRONTEND as string),
+    };
     return expect(
         github.ghExchangeAccessToken(req, res)
     ).resolves.not.toThrow();

--- a/backend/tests/routes_unit/github.test.ts
+++ b/backend/tests/routes_unit/github.test.ts
@@ -144,7 +144,7 @@ test("ghIdentity correctly redirects", async () => {
         "state=";
     utilMock.redirect.mockReset();
     utilMock.redirect.mockImplementation(async (_, url) => {
-        await expect(url).toBe(exp + github.states[0]);
+        expect(url).toBe(exp + github.states[0]);
     });
 
     await github.ghIdentity(getMockRes().res);
@@ -219,7 +219,12 @@ test("Can detect if name changes are required", () => {
 
 test("Can login if the account exists", async () => {
     const input = { login: "@my_github", name: "my", id: "69" };
-    const output = { sessionkey: "abcd", is_admin: true, is_coach: true };
+    const output = {
+        sessionkey: "abcd",
+        is_admin: true,
+        is_coach: true,
+        is_signup: false,
+    };
     const f = new Date(Date.now());
     f.setDate(f.getDate() + session_key.valid_period);
 
@@ -235,7 +240,12 @@ test("Can login if the account exists", async () => {
 
 test("Can login if the account exists and update username", async () => {
     const input = { login: "@my_github", name: "alo", id: "69" };
-    const output = { sessionkey: "abcd", is_admin: true, is_coach: true };
+    const output = {
+        sessionkey: "abcd",
+        is_admin: true,
+        is_coach: true,
+        is_signup: false,
+    };
     const f = new Date(Date.now());
     f.setDate(f.getDate() + session_key.valid_period);
 
@@ -256,7 +266,12 @@ test("Can login if the account exists and update username", async () => {
 
 test("Can login if the account exists and update github handle", async () => {
     const input = { login: "@jefke", name: "my", id: "69" };
-    const output = { sessionkey: "abcd", is_admin: true, is_coach: true };
+    const output = {
+        sessionkey: "abcd",
+        is_admin: true,
+        is_coach: true,
+        is_signup: false,
+    };
     const f = new Date(Date.now());
     f.setDate(f.getDate() + session_key.valid_period);
 
@@ -277,7 +292,12 @@ test("Can login if the account exists and update github handle", async () => {
 
 test("Can register if account doesn't exist", async () => {
     const input = { login: "@jefke", name: "my", id: "-69" };
-    const output = { sessionkey: "abcd", is_admin: false, is_coach: true };
+    const output = {
+        sessionkey: "abcd",
+        is_admin: false,
+        is_coach: true,
+        is_signup: true,
+    };
     const f = new Date(Date.now());
     f.setDate(f.getDate() + session_key.valid_period);
 
@@ -325,6 +345,9 @@ test("Can exchange access token for session key", async () => {
     const code = "abcdefghijklmnopqrstuvwxyz";
 
     axiosMock.post.mockImplementation((url, body, conf) => {
+        console.log(
+            "POST request to " + url + " with config " + JSON.stringify(conf)
+        );
         expect(url).toBe("https://github.com/login/oauth/access_token");
         expect(conf).toHaveProperty("headers.Accept", "application/json");
         expect(body).toStrictEqual({
@@ -339,6 +362,9 @@ test("Can exchange access token for session key", async () => {
     });
 
     axiosMock.get.mockImplementation((url, conf) => {
+        console.log(
+            "GET request to " + url + " with config " + JSON.stringify(conf)
+        );
         expect(url).toBe("https://api.github.com/user");
         expect(conf).toHaveProperty(
             "headers.Authorization",
@@ -351,7 +377,7 @@ test("Can exchange access token for session key", async () => {
     });
 
     utilMock.redirect.mockImplementation(async (_, url) => {
-        expect(url).toBe(process.env.FRONTEND + "/login/abcd");
+        expect(url).toBe(process.env.FRONTEND + "/login/abcd?is_signup=false");
         return Promise.resolve();
     });
 

--- a/backend/types.ts
+++ b/backend/types.ts
@@ -473,6 +473,14 @@ export namespace Responses {
     }
 
     /**
+     *  A GitHub login response differs from a normal login response by the added
+     * is_signup field, which should tell the client that this user was newly created.
+     */
+    export interface GithubLogin extends Login {
+        is_signup: boolean;
+    }
+
+    /**
      *  A partial student response is the keyed combination of their id and name.
      */
     export interface PartialStudent extends InternalTypes.IdName {}


### PR DESCRIPTION
Fixes #552 and #461

 - [x] Add extra data field to GitHub successful login response
 - [x] Make GitHub URL callbacks generic (with default)
 - [x] Set default in config ( -> **EDIT** done via dot-env)
 - [x] Fix tests

The new field is `is_signup`. This means that the whole URL is now `<FE URL>/login/<SESSIONKEY>?is_signup=<true/false>`. The field shall be `true` when a new account is created, and `false` otherwise.

You can also specify a different frontend URL by passing the `?callback=<ABSOLUTE URL>` parameter to the original signup request (`GET /github`).