### PR TITLE
added osocyear to project filter

### DIFF
--- a/backend/orm_functions/project.ts
+++ b/backend/orm_functions/project.ts
@@ -301,6 +301,7 @@ export async function deleteProjectByPartner(partner: string) {
  * @param clientNameFilter client name that we are filtering on (or undefined if not filtering on name)
  * @param assignedCoachesFilterArray assigned coaches that we are filtering on (or undefined if not filtering on assigned coaches)
  * @param fullyAssignedFilter fully assigned status that we are filtering on (or undefined if not filtering on assigned)
+ * @param osocYearFilter: the osoc year the project belongs to (or undefined if not filtering on year)
  * @param projectNameSort asc or desc if we want to sort on project name, undefined if we are not sorting on project name
  * @param clientNameSort asc or desc if we want to sort on client name, undefined if we are not sorting on client name
  * @returns the filtered students with their person data and other filter fields in a promise
@@ -311,6 +312,7 @@ export async function filterProjects(
     clientNameFilter: FilterString = undefined,
     assignedCoachesFilterArray: FilterNumberArray = undefined,
     fullyAssignedFilter: FilterBoolean = undefined,
+    osocYearFilter: number | undefined = undefined,
     projectNameSort: FilterSort = undefined,
     clientNameSort: FilterSort = undefined
 ) {
@@ -336,6 +338,9 @@ export async function filterProjects(
     }
 
     const actualFilter: Prisma.projectWhereInput = {
+        osoc: {
+            year: osocYearFilter,
+        },
         name: {
             contains: projectNameFilter,
             mode: "insensitive",

--- a/backend/request.ts
+++ b/backend/request.ts
@@ -707,6 +707,7 @@ export async function parseFilterProjectsRequest(
         clientNameFilter: maybe(req.body, "clientNameFilter"),
         assignedCoachesFilterArray: assignedCoachesFilterArray,
         fullyAssignedFilter: fullyAssignedFilter,
+        osocYearFilter: maybe(req.body, "osocYearFilter"),
         projectNameSort: maybe(req.body, "projectNameSort"),
         clientNameSort: maybe(req.body, "clientNameSort"),
     });

--- a/backend/types.ts
+++ b/backend/types.ts
@@ -1346,6 +1346,7 @@ export namespace Requests {
         clientNameFilter?: string;
         assignedCoachesFilterArray?: number[];
         fullyAssignedFilter?: boolean;
+        osocYearFilter?: number;
         projectNameSort?: FilterSort;
         clientNameSort?: FilterSort;
     }


### PR DESCRIPTION
This pr adds the osocyear filter to the project filter.
This will close issue #519
It is currently configured that when no osocyear parameter is given it will automatically take the latest edition.
Please give your opinion on this.