### PR TITLE
fix: scroll state is remembered in the manage user screen

### DIFF
--- a/frontend/pages/users.tsx
+++ b/frontend/pages/users.tsx
@@ -69,6 +69,7 @@ const Users: NextPage = () => {
         socket.off("registrationReceived");
         // add new listener
         socket.on("loginUserUpdated", () => {
+            const scrollPosition = window.scrollY;
             search(
                 {
                     nameFilter: searchParams.nameFilter,
@@ -81,8 +82,10 @@ const Users: NextPage = () => {
                 },
                 pagination.page
             ).then();
+            window.scrollTo(0, scrollPosition);
         });
         socket.on("registrationReceived", () => {
+            const scrollPosition = window.scrollY;
             search(
                 {
                     nameFilter: searchParams.nameFilter,
@@ -95,6 +98,7 @@ const Users: NextPage = () => {
                 },
                 pagination.page
             ).then();
+            window.scrollTo(0, scrollPosition);
         });
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [socket, searchParams]);


### PR DESCRIPTION
we now remember the scrolling position on the manage users screen.

The other screens will be implemented when I fix the websockets in those screens.

To test this you'll need to add some loginusers until the amount of users is longer than can be displayed without scrolling.
Make sure you're scrolled down in 1 of your windows and change permissions in the other window.