### PR TITLE
Add login_user_id to GET /coach/all

### DIFF
--- a/backend/routes/coach.ts
+++ b/backend/routes/coach.ts
@@ -35,6 +35,7 @@ export async function listCoaches(
                         coach: val.is_coach,
                         admin: val.is_admin,
                         activated: val.account_status as string,
+                        login_user_id: val.login_user_id,
                     }))
                 )
                 .then((obj) =>

--- a/backend/tests/routes_unit/coach.test.ts
+++ b/backend/tests/routes_unit/coach.test.ts
@@ -201,6 +201,7 @@ test("Can list all coaches", async () => {
         coach: val.is_coach,
         admin: val.is_admin,
         activated: val.account_status as string,
+        login_user_id: val.login_user_id,
     }));
 
     await expect(coach.listCoaches(req)).resolves.toStrictEqual({

--- a/backend/types.ts
+++ b/backend/types.ts
@@ -686,6 +686,7 @@ export namespace InternalTypes {
         coach: boolean;
         admin: boolean;
         activated: string;
+        login_user_id: number;
     }
 
     /**


### PR DESCRIPTION
The **login_user_id** is added to the coach objects that the route **GET /coach/all** returns.